### PR TITLE
Improve navigation and preview

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -11,6 +11,7 @@
         "@artifact/client": "npm:@jsr/artifact__client@^0.0.113",
         "fast-deep-equal": "^3.1.3",
         "lucide-react": "^0.513.0",
+        "marked": "^12.0.2",
         "react": "^19.1.0",
         "react-dom": "^19.1.0",
         "zod": "^3.25.56",
@@ -3921,6 +3922,18 @@
       "license": "MIT",
       "dependencies": {
         "@jridgewell/sourcemap-codec": "^1.5.0"
+      }
+    },
+    "node_modules/marked": {
+      "version": "12.0.2",
+      "resolved": "https://registry.npmjs.org/marked/-/marked-12.0.2.tgz",
+      "integrity": "sha512-qXUm7e/YKFoqFPYPa3Ukg9xlI5cyAtGmyEIzMfW//m6kXwCy2Ps9DYf5ioijFKQ8qyuscrHoY04iJGctu2Kg0Q==",
+      "license": "MIT",
+      "bin": {
+        "marked": "bin/marked.js"
+      },
+      "engines": {
+        "node": ">= 18"
       }
     },
     "node_modules/math-intrinsics": {

--- a/package.json
+++ b/package.json
@@ -20,6 +20,7 @@
     "@artifact/client": "npm:@jsr/artifact__client@^0.0.113",
     "fast-deep-equal": "^3.1.3",
     "lucide-react": "^0.513.0",
+    "marked": "^12.0.2",
     "react": "^19.1.0",
     "react-dom": "^19.1.0",
     "zod": "^3.25.56",

--- a/src/FilesView.tsx
+++ b/src/FilesView.tsx
@@ -44,6 +44,12 @@ const FilesView: React.FC = () => {
     setShowFileDetails(false)
   }
 
+  const handleNavigateTo = (path: string) => {
+    setCurrentPath(path)
+    setSelectedFile(null)
+    setShowFileDetails(false)
+  }
+
   const isAtRoot = !currentPath
 
   return (
@@ -87,6 +93,7 @@ const FilesView: React.FC = () => {
         currentPath={currentPath}
         isAtRoot={isAtRoot}
         onNavigateUp={handleNavigateUp}
+        onNavigateTo={handleNavigateTo}
       />
 
       <div className="flex flex-1 overflow-hidden">

--- a/src/components/FileDetails.tsx
+++ b/src/components/FileDetails.tsx
@@ -1,5 +1,6 @@
-import React from 'react'
+import React, { useMemo } from 'react'
 import { ChevronDown, FileText, Edit, Download, File } from 'lucide-react'
+import { marked } from 'marked'
 import { useArtifact } from '@artifact/client/hooks'
 
 interface Props {
@@ -38,6 +39,37 @@ const FileDetails: React.FC<Props> = ({
     link.click()
     URL.revokeObjectURL(url)
   }
+
+  const preview = useMemo(() => {
+    if (!fileData) return null
+    const ext = selectedFile.split('.').pop()?.toLowerCase() || ''
+    const blob = new Blob([fileData])
+
+    if (['png', 'jpg', 'jpeg', 'gif', 'svg', 'webp'].includes(ext)) {
+      const url = URL.createObjectURL(blob)
+      return (
+        <img
+          src={url}
+          className="max-h-96 mx-auto"
+          onLoad={() => URL.revokeObjectURL(url)}
+        />
+      )
+    }
+
+    const text = new TextDecoder().decode(fileData)
+
+    if (['md', 'markdown'].includes(ext)) {
+      const html = marked.parse(text)
+      return (
+        <div
+          className="markdown-preview"
+          dangerouslySetInnerHTML={{ __html: html }}
+        />
+      )
+    }
+
+    return <pre className="whitespace-pre-wrap text-sm font-mono">{text}</pre>
+  }, [fileData, selectedFile])
 
   return (
     <div className="w-1/2 pl-4 overflow-auto">
@@ -104,14 +136,13 @@ const FileDetails: React.FC<Props> = ({
 
         <div className="border-t border-gray-200 pt-4 mt-4">
           <h4 className="font-medium mb-2">Preview</h4>
-          <div className="bg-gray-50 p-4 rounded-md h-40 overflow-auto">
-            <div className="text-gray-400 text-center flex flex-col items-center justify-center h-full">
-              <FileText size={24} className="mb-2" />
-              <span>Preview not available</span>
-              <span className="text-xs mt-1">
-                Click "View Content" to see the file
-              </span>
-            </div>
+          <div className="bg-gray-50 p-4 rounded-md max-h-96 overflow-auto">
+            {preview || (
+              <div className="text-gray-400 text-center flex flex-col items-center justify-center h-full">
+                <FileText size={24} className="mb-2" />
+                <span>Preview not available</span>
+              </div>
+            )}
           </div>
         </div>
       </div>

--- a/src/components/NavigationBar.tsx
+++ b/src/components/NavigationBar.tsx
@@ -1,16 +1,18 @@
 import React from 'react'
-import { ArrowUp } from 'lucide-react'
+import { ArrowUp, ChevronRight } from 'lucide-react'
 
 interface Props {
   currentPath: string
   isAtRoot: boolean
   onNavigateUp: () => void
+  onNavigateTo: (path: string) => void
 }
 
 const NavigationBar: React.FC<Props> = ({
   currentPath,
   isAtRoot,
-  onNavigateUp
+  onNavigateUp,
+  onNavigateTo
 }) => (
   <div className="bg-white rounded-lg border border-gray-200 p-3 mb-4 flex items-center">
     <div className="flex items-center">
@@ -28,8 +30,29 @@ const NavigationBar: React.FC<Props> = ({
       </button>
 
       <span className="text-gray-500 mr-2">Path:</span>
-      <span className="text-blue-600 mr-1 font-medium">/</span>
-      {currentPath && <span className="text-gray-600">{currentPath}</span>}
+      <button
+        onClick={() => onNavigateTo('')}
+        className="text-blue-600 mr-1 font-medium hover:text-blue-800"
+      >
+        /
+      </button>
+      {currentPath
+        .split('/')
+        .filter((p) => p)
+        .map((part, idx, arr) => {
+          const path = arr.slice(0, idx + 1).join('/')
+          return (
+            <React.Fragment key={path}>
+              <ChevronRight size={16} className="text-gray-400" />
+              <button
+                onClick={() => onNavigateTo(path)}
+                className="text-blue-600 ml-1 hover:text-blue-800"
+              >
+                {part}
+              </button>
+            </React.Fragment>
+          )
+        })}
     </div>
   </div>
 )

--- a/src/index.css
+++ b/src/index.css
@@ -4,3 +4,15 @@ body {
   font-family: sans-serif;
   margin: 0;
 }
+
+.markdown-preview {
+  font-family: sans-serif;
+  font-size: 0.875rem;
+  line-height: 1.25rem;
+}
+.markdown-preview pre {
+  background-color: #f3f4f6;
+  padding: 0.5rem;
+  border-radius: 0.25rem;
+  overflow: auto;
+}


### PR DESCRIPTION
## Summary
- add clickable breadcrumbs to navigation bar
- show markdown, image, and code previews in file details panel
- wire breadcrumb navigation into file view
- style markdown preview
- include `marked` library

## Testing
- `npm run ok`

------
https://chatgpt.com/codex/tasks/task_e_684611c8bfb8832b94c6bdc56091be2a