### PR TITLE
Add basic file/folder creation and rename

### DIFF
--- a/src/FilesView.tsx
+++ b/src/FilesView.tsx
@@ -13,6 +13,26 @@ const FilesView: React.FC = () => {
   const [showFileDetails, setShowFileDetails] = useState(false)
   const fileInputRef = useRef<HTMLInputElement>(null)
 
+  const handleCreateFile = async () => {
+    const name = prompt('Enter new file name')
+    if (!name) return
+    const path = currentPath ? `${currentPath}/${name}` : name
+    artifact.files.write.text(path, '')
+    if (artifact.files.isDirty()) {
+      await artifact.branch.write.commit(`Add file ${name}`)
+    }
+  }
+
+  const handleCreateFolder = async () => {
+    const name = prompt('Enter new folder name')
+    if (!name) return
+    const dir = currentPath ? `${currentPath}/${name}` : name
+    artifact.files.write.text(`${dir}/.gitkeep`, '')
+    if (artifact.files.isDirty()) {
+      await artifact.branch.write.commit(`Add folder ${name}`)
+    }
+  }
+
   const folderContents = useDir(currentPath || '.') || []
 
   const filePath = selectedFile || ''
@@ -59,13 +79,27 @@ const FilesView: React.FC = () => {
           <File className="mr-2" size={24} />
           Files
         </h1>
-        <button
-          className="bg-blue-500 hover:bg-blue-600 text-white px-4 py-2 rounded-md flex items-center transition-colors"
-          onClick={() => fileInputRef.current?.click()}
-        >
-          <Upload size={16} className="mr-2" />
-          Upload
-        </button>
+        <div className="flex gap-2">
+          <button
+            className="bg-blue-500 hover:bg-blue-600 text-white px-4 py-2 rounded-md flex items-center transition-colors"
+            onClick={handleCreateFile}
+          >
+            New File
+          </button>
+          <button
+            className="bg-blue-500 hover:bg-blue-600 text-white px-4 py-2 rounded-md flex items-center transition-colors"
+            onClick={handleCreateFolder}
+          >
+            New Folder
+          </button>
+          <button
+            className="bg-blue-500 hover:bg-blue-600 text-white px-4 py-2 rounded-md flex items-center transition-colors"
+            onClick={() => fileInputRef.current?.click()}
+          >
+            <Upload size={16} className="mr-2" />
+            Upload
+          </button>
+        </div>
         <input
           ref={fileInputRef}
           type="file"
@@ -114,6 +148,7 @@ const FilesView: React.FC = () => {
             fileData={fileData}
             fileMeta={fileMeta}
             onClose={() => setShowFileDetails(false)}
+            onRename={(newPath) => setSelectedFile(newPath)}
           />
         )}
       </div>

--- a/src/components/FileList.tsx
+++ b/src/components/FileList.tsx
@@ -52,6 +52,7 @@ const FileList: React.FC<Props> = ({
 
       <div className="overflow-auto">
         {[...folderContents]
+          .filter((m) => m.path !== '.gitkeep')
           .sort((a, b) => {
             if (a.type === 'tree' && b.type !== 'tree') return -1
             if (a.type !== 'tree' && b.type === 'tree') return 1


### PR DESCRIPTION
## Summary
- allow creating new files and folders
- hide `.gitkeep` placeholder entries
- support renaming files via editable breadcrumb path

## Testing
- `npm run lint`
- `npm run type-check`
- `npm run build`
- `npm run ok`


------
https://chatgpt.com/codex/tasks/task_e_68465c61ecb4832b986188befd183fb0