### PR TITLE
Add commit pinned banner

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -1,6 +1,7 @@
 import { useState, useRef } from 'react'
 import { File, Upload } from 'lucide-react'
 import { useArtifact, useDir, useFile, useMeta } from '@artifact/client/hooks'
+import CommitBanner from './components/CommitBanner.tsx'
 import NavigationBar from './components/NavigationBar.tsx'
 import FileList, { type FileItem } from './components/FileList.tsx'
 import FileDetails from './components/FileDetails.tsx'
@@ -76,6 +77,7 @@ export default function App() {
 
   return (
     <div className="p-6 animate-fadeIn h-full flex flex-col">
+      <CommitBanner />
       <div className="flex justify-between items-center mb-6">
         <h1 className="text-2xl font-bold flex items-center">
           <File className="mr-2" size={24} />

--- a/src/components/CommitBanner.tsx
+++ b/src/components/CommitBanner.tsx
@@ -1,0 +1,28 @@
+import { useFrame } from '@artifact/client/hooks'
+
+export default function CommitBanner() {
+  const frame = useFrame()
+  const target = frame.target as Record<string, unknown>
+
+  if ('commit' in target && typeof target.commit === 'string') {
+    const { did, repo, branch, commit } = target as {
+      did: string
+      repo: string
+      branch: string
+      commit: string
+    }
+    const short = commit.slice(0, 7)
+    const handle = () => {
+      frame.onNavigateTo?.({ did, repo, branch })
+    }
+    return (
+      <div className="bg-yellow-100 text-yellow-800 px-4 py-2 rounded mb-4 flex justify-between items-center">
+        <span className="text-sm font-medium">Pinned to commit {short}</span>
+        <button className="text-sm underline" onClick={handle}>
+          Switch to latest
+        </button>
+      </div>
+    )
+  }
+  return null
+}


### PR DESCRIPTION
## Summary
- show a banner when the frame is pinned to a commit
- add a button to navigate back to the latest commit

## Testing
- `npm run ok`

------
https://chatgpt.com/codex/tasks/task_e_6854d31e72cc832bb8608af8b76ef046