### PR TITLE
Fix unpin action to notify host

### DIFF
--- a/src/components/CommitBanner.tsx
+++ b/src/components/CommitBanner.tsx
@@ -13,7 +13,7 @@ export default function CommitBanner() {
     }
     const short = commit.slice(0, 7)
     const handle = () => {
-      frame.onNavigateTo?.({ did, repo, branch })
+      frame.onSelection?.({ did, repo, branch })
     }
     return (
       <div className="bg-yellow-100 text-yellow-800 px-4 py-2 rounded mb-4 flex justify-between items-center">


### PR DESCRIPTION
## Summary
- trigger `onSelection` instead of `onNavigateTo` when unpinning from a commit

## Testing
- `npm run ok`

------
https://chatgpt.com/codex/tasks/task_e_685cbaf4f154832ba89dffc758f48f37