### PR TITLE
Enable scroll within file list

### DIFF
--- a/src/components/FileList.tsx
+++ b/src/components/FileList.tsx
@@ -50,7 +50,7 @@ const FileList: React.FC<Props> = ({
   }
 
   return (
-    <div className="bg-white rounded-lg border border-gray-200  h-full">
+    <div className="bg-white rounded-lg border border-gray-200 h-full flex flex-col">
       <div className="grid grid-cols-12 gap-4 p-4 font-medium text-gray-500 text-sm border-b border-gray-200">
         <div className="col-span-5">Name</div>
         <div className="col-span-3">Modified</div>
@@ -58,7 +58,7 @@ const FileList: React.FC<Props> = ({
         <div className="col-span-2">Size</div>
       </div>
 
-      <div className="overflow-auto">
+      <div className="flex-1 overflow-y-auto">
         {[...folderContents]
           .filter((m) => m.path !== '.gitkeep')
           .sort((a, b) => {


### PR DESCRIPTION
## Summary
- allow the file list section to scroll when its content grows too long

## Testing
- `npm run ok`

------
https://chatgpt.com/codex/tasks/task_e_68777a280c38832b83a68dce6b57e01a